### PR TITLE
Fix incorrect newlines

### DIFF
--- a/easymotion.kak
+++ b/easymotion.kak
@@ -72,12 +72,12 @@ pydef 'easy-motion-on-selections -params 0..2' '%opt{em_jumpchars}^%val{timestam
 
     jumps.append("*) echo select " + first + " ;;")
 
-    return "\\n".join((
+    return "\n".join((
         "select " + first,
         "easy-motion-rmhl",
         "easy-motion-addhl",
         "set window em_fg " + fg,
-        "on-key %< eval %sh< case $kak_key in " + "\\n".join(jumps),
+        "on-key %< eval %sh< case $kak_key in " + "\n".join(jumps),
         "*) echo select " + first,
         "esac >; easy-motion-rmhl; " + callback + " >"))
 }


### PR DESCRIPTION
Current version fails with a message
```
Error: 1:1: 'easy-motion-w' 1:2: 'easy-motion-on-regex' 3:62: 'easy-motion-on-selections' 3:304: 'eval' 1:1: 'select' 1\neasy-motion-rmhl\neasy-motion-addhl\nset is not a
6│ number
```
This is due to incorrect newlines (`\\n`) in kak script. This changes them to correct ones (`\n`).