### PR TITLE
Improve split robustness to handle Kakoune master

### DIFF
--- a/easymotion.kak
+++ b/easymotion.kak
@@ -80,11 +80,12 @@ def _on_key -hidden -params .. %{
     }}
 }
 
-pydef 'easy-motion-on-selections -params 0..3' '%opt{em_jumpchars}^%val{timestamp}^%arg{1}^%arg{2}^%arg{3}^%val{selections_desc}' %{
+pydef 'easy-motion-on-selections -params ..3' '%opt{em_jumpchars}^%val{timestamp}^%arg{1}^%arg{2}^%arg{3}^%val{selections_desc}' %{
     jumpchars, timestamp, direction, callback_chosen, callback_cancel, descs = stdin.strip().split("^")
     if len(jumpchars) <= 1:
         return 'fail em_jumpchars needs length at least two'
-    descs = descs.split(" ")
+    import re
+    descs = re.split("[^\d,.]+", descs)
     from collections import OrderedDict, defaultdict
     jumpchars = list(OrderedDict.fromkeys(jumpchars))
     if direction == 't':


### PR DESCRIPTION
Hello, 

I propose here a solution to the Issue #21 
After the commit 0a66eb9c47ba9a7d3b90286d66a70b5bd7eee15a in kakoune,
the descs variable in the python context contains '\x0' characters
instead of spaces. Using a regex to split everything expect numbers and
punctuation solve this problem.
This change should also be compatible with versions before the given commit.

This PR fixed #21 

Best,
Charles